### PR TITLE
Add handler to handle stale cached config version

### DIFF
--- a/handlers/config-site-version-cache-stale.js
+++ b/handlers/config-site-version-cache-stale.js
@@ -1,0 +1,38 @@
+/**
+ * config-site-version-cache-stale
+ * return the bootstrap version information needed for the given tenant.
+ */
+
+let { ConfigVersionCache } = require("../utils/cache");
+
+module.exports = {
+   /**
+    * Key: the cote message key we respond to.
+    */
+   key: "tenant_manager.site-version-cache-stale",
+
+   inputValidation: {},
+
+   /**
+    * fn
+    * our Request handler.
+    * @param {obj} req
+    *        the request object sent by the api_sails/api/controllers/tenant_manager/config.
+    * @param {fn} cb
+    *        a node style callback(err, results) to send data when job is finished
+    */
+   fn: async function handler(req, cb) {
+      req.log("tenant_manager.site-version-cache-stale");
+      try {
+         const tenantID = req.param("tenantID") ?? req.tenantID();
+         if (tenantID === "all") {
+            ConfigVersionCache = {};
+         } else {
+            delete ConfigVersionCache[tenantID];
+         }
+         cb();
+      } catch (err) {
+         cb(err);
+      }
+   },
+};

--- a/handlers/config-site-version.js
+++ b/handlers/config-site-version.js
@@ -1,13 +1,10 @@
 /**
- * config-site-verstion
+ * config-site-version
  * return the bootstrap version information needed for the given tenant.
  */
 
+const { ConfigVersionCache } = require("../utils/cache.js");
 const TMConfigSite = require("./config-site.js");
-
-var CacheVersion = {
-   /* tenantID : "config version hash" */
-};
 
 /**
  * @function hashCode()
@@ -65,7 +62,7 @@ module.exports = {
       req.log("tenant_manager.config-site-version()");
       try {
          let tenantID = req.tenantID();
-         let version = CacheVersion[tenantID];
+         let version = ConfigVersionCache[tenantID];
          if (!version) {
             await new Promise((resolve, reject) => {
                TMConfigSite.fn(req, (err, result) => {
@@ -74,7 +71,7 @@ module.exports = {
                      result = JSON.stringify(result);
                   }
                   version = new String(hashCode(result)).toString();
-                  CacheVersion[tenantID] = version;
+                  ConfigVersionCache[tenantID] = version;
                   resolve();
                });
             });

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,9 @@
+/**
+ * Basic Memory Cache
+ */
+
+/** @type {Object<string, string>} */
+const ConfigVersionCache = {
+   /* tenantID : "config version hash" */
+};
+module.exports = { ConfigVersionCache };


### PR DESCRIPTION
Should fix issue with Switcheroo test https://github.com/digi-serve/ab_runtime/pull/366.
## Release Notes
<!-- #release_notes -->
- allow the site config version cache to be rest 
<!-- /release_notes --> 
