### PR TITLE
Switch deployment to the #main branch until the AWS ab-utils changes are merged

### DIFF
--- a/.github/workflows/build-deploy-ecs.yml
+++ b/.github/workflows/build-deploy-ecs.yml
@@ -1,0 +1,36 @@
+name: Build & Deploy ECS
+
+on:
+  push:
+    branches:
+      # Automatically build master and staging. Additional branches may be added.
+      - main
+      - staging
+  workflow_dispatch:
+    # Allows manual build and deploy of any branch/ref
+    inputs:
+      auto-deploy:
+        type: boolean
+        description: Deploy image after building?
+        required: true
+        default: 'false'
+jobs:
+  # Build and push container image to ECR. Builds occur in the project repository.
+  build:
+    name: Build
+    uses: CruGlobal/.github/.github/workflows/build-ecs.yml@v1
+
+  # Triggers an ECS deployment in https://github.com/CruGlobal/cru-deploy/actions.
+  # All deployments happen in the cru-deploy repo.
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.auto-deploy == 'true'
+    steps:
+      - uses: CruGlobal/.github/actions/trigger-deploy@v1
+        with:
+          github-token: ${{ secrets.CRU_DEPLOY_GITHUB_TOKEN }}
+          project-name: ${{ needs.build.outputs.project-name }}
+          environment: ${{ needs.build.outputs.environment }}
+          build-number: ${{ needs.build.outputs.build-number }}


### PR DESCRIPTION
Switch deployment to the #main branch until the AWS ab-utils changes are merged
[CruGlobal/ab-utils#77](https://github.com/CruGlobal/ab-utils/pull/77)
[CruGlobal/global-hr-update#405](https://github.com/CruGlobal/global-hr-update/issues/405)